### PR TITLE
fix: keys generation and backend start 

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import fs from 'fs'
 
 import dotenv from 'dotenv'
 
@@ -106,7 +105,6 @@ async function compareKey(
     )
   }
 }
-
 
 // Set Cookie Options: (list of ingredients)
 export const cookieOptions: CookieOptions = {

--- a/backend/src/utils/generateKeyPairs.ts
+++ b/backend/src/utils/generateKeyPairs.ts
@@ -17,9 +17,16 @@ export function generateKeyPairs(mnemonic: string) {
     Kilt.Utils.Crypto.mnemonicToMiniSecret(mnemonic)
   )
 
+  // This key is not necessary for this project:
+  const capabilityDelegation = Kilt.Utils.Crypto.makeKeypairFromUri(
+    mnemonic,
+    signingKeyPairType
+  )
+
   return {
     authentication,
     assertionMethod,
-    keyAgreement
+    keyAgreement,
+    capabilityDelegation
   }
 }

--- a/backend/src/utils/generateKeyPairs.ts
+++ b/backend/src/utils/generateKeyPairs.ts
@@ -17,7 +17,8 @@ export function generateKeyPairs(mnemonic: string) {
     Kilt.Utils.Crypto.mnemonicToMiniSecret(mnemonic)
   )
 
-  // This key is not necessary for this project:
+  // This key is not necessary for this project.
+  // for the sake of completeness, your dApp's DID also gets one
   const capabilityDelegation = Kilt.Utils.Crypto.makeKeypairFromUri(
     mnemonic,
     signingKeyPairType

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "yarn build:frontend && yarn build:backend",
     "start:frontend": "ts-node ./scripts/updatePorts.ts && cd ./frontend && yarn start",
     "start:backend": "cd ./backend && yarn start",
-    "start:backend-prod": "cd ./backend && yarn start-prod",
+    "start-prod:backend": "cd ./backend && yarn start-prod",
     "start": "concurrently 'yarn:start:*'",
     "lint": "concurrently 'yarn:lint:*'",
     "lint:frontend": "eslint --ext .js,.ts --config ./.eslintrc.json \"frontend/**/*.ts\"",

--- a/scripts/genesisEnvironmentVariables.ts
+++ b/scripts/genesisEnvironmentVariables.ts
@@ -124,7 +124,7 @@ function imploreWebSocket() {
 
     'Please, define a value for WSS_ADDRESS on the .env-file to continue \n',
     'To connect to the KILT-Test-Blockchain, named Peregrine (recommended), please save the following: \n\n',
-    'WSS_ADDRESS=wss://peregrine.kilt.io/parachain-public-ws',
+    'WSS_ADDRESS=wss://peregrine.kilt.io/',
     '\n\n',
 
     'In the future, if you wish to interact with the production KILT-Blockchain, named Spiritnet, change the address to a web-socket (public Endpoint) of Spiritnet.',

--- a/scripts/launchUtils/generateKeyPairs.ts
+++ b/scripts/launchUtils/generateKeyPairs.ts
@@ -1,51 +1,33 @@
-import {
-  mnemonicToMiniSecret,
-  sr25519PairFromSeed,
-  keyExtractPath,
-  keyFromPath,
-  blake2AsU8a
-} from '@polkadot/util-crypto'
 import * as Kilt from '@kiltprotocol/sdk-js'
 
-function generateKeyAgreement(mnemonic: string) {
-  const secretKeyPair = sr25519PairFromSeed(mnemonicToMiniSecret(mnemonic))
-  const { path } = keyExtractPath('//did//keyAgreement//0')
-  const { secretKey } = keyFromPath(secretKeyPair, path, 'sr25519')
-  return Kilt.Utils.Crypto.makeEncryptionKeypairFromSeed(blake2AsU8a(secretKey))
-}
+const signingKeyPairType = 'sr25519'
 
 export function generateKeyPairs(mnemonic: string) {
-  // Currently, the default the key type used by the Kilt-team is "sr25519". Better to use it for compatibility.
-  const account = Kilt.Utils.Crypto.makeKeypairFromSeed(
-    mnemonicToMiniSecret(mnemonic),
-    'sr25519'
+  const authentication = Kilt.Utils.Crypto.makeKeypairFromUri(
+    mnemonic,
+    signingKeyPairType
   )
 
-  // You can derive the keys however you want to and it will still work.
-  // But if, for example, you try to load your seed phrase in a third party wallet, you will get a different set of keys, because the derivation is different.
-  // For a start, it is better to use the same derivations as Sporran. So you can load your Accounts and DIDs there and check if everything worked fine.
+  const assertionMethod = Kilt.Utils.Crypto.makeKeypairFromUri(
+    mnemonic,
+    signingKeyPairType
+  )
 
-  const authentication = account.derive('//did//0') as Kilt.KiltKeyringPair
+  const keyAgreement = Kilt.Utils.Crypto.makeEncryptionKeypairFromSeed(
+    Kilt.Utils.Crypto.mnemonicToMiniSecret(mnemonic)
+  )
 
-  const assertionMethod = account.derive(
-    '//did//assertion//0'
-  ) as Kilt.KiltKeyringPair
-
-  // the delegation Keys are not needed for this project.
-  const capabilityDelegation = account.derive(
-    '//did//delegation//0'
-  ) as Kilt.KiltKeyringPair
-
-  // The encryption keys, a.k.a. keyAgreement, are not natively supported by the polkadot library.
-  // So to derive this kinds of keys, we have to play a bit with lower-level details.
-  // Thats whats done in the extra function generateKeyAgreement()
-
-  const keyAgreement = generateKeyAgreement(mnemonic)
+  // This key is not necessary for this project.
+  // for the sake of completeness, your dApp's DID also gets one
+  const capabilityDelegation = Kilt.Utils.Crypto.makeKeypairFromUri(
+    mnemonic,
+    signingKeyPairType
+  )
 
   return {
-    authentication: authentication,
-    keyAgreement: keyAgreement,
-    assertionMethod: assertionMethod,
-    capabilityDelegation: capabilityDelegation
+    authentication,
+    assertionMethod,
+    keyAgreement,
+    capabilityDelegation
   }
 }


### PR DESCRIPTION
## fixes KILTProtocol/NO Ticket

The newest implementations on this project were not letting me start the backend. 

The __key generation__ used for the `well-known-did-config` and the `.env`-variables (and consequently the ones on chain) was different than the __key generation__ on the backend and therefore the one used for signing. The `config` verifies this and was throwing. 

The `backend-prod`  was being concurrently started with the `frontend` and the `backend` and therefore stealing the backend's port and not letting him exist. 

These troubles should be fixed now. 