### PR TITLE
feat: accept credentials from SocialKYC on Spiritnet as well

### DIFF
--- a/backend/src/credentials/listOfRequests.ts
+++ b/backend/src/credentials/listOfRequests.ts
@@ -6,7 +6,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
  * Usually, attesters have different DIDs depending on the blockchain, i.e. production or testnet.
  *
  * On the other hand, a cType Hash is calculated from the cType structure.
- * If exactly the same structure is used on the test and production, the cType Hash would be the same.
+ * If exactly the same structure is used on the test and production, the cType Hash will be the same.
  */
 
 /**

--- a/backend/src/credentials/listOfRequests.ts
+++ b/backend/src/credentials/listOfRequests.ts
@@ -6,7 +6,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
  * Usually, attesters have different DIDs depending on the blockchain, i.e. production or testnet.
  *
  * On the other hand, a cType Hash is calculated from the cType structure.
- * If exactly the same structure is used on the test and production , the cType hash would be the same.
+ * If exactly the same structure is used on the test and production, the cType Hash would be the same.
  */
 
 /**

--- a/backend/src/credentials/listOfRequests.ts
+++ b/backend/src/credentials/listOfRequests.ts
@@ -4,7 +4,12 @@ import { WSS_ADDRESS } from '../config'
 
 // Establish which cTypes our dApp accepts and which attesters we trust:
 
-// DIDs and cType-Hashes are different depending on the blockchain:
+/**
+ * Usually, attesters have different DIDs depending on the blockchain, i.e. production or testnet.
+ *
+ * The cType Hash is calculated from the cType structure.
+ * If exactly the same structure is used on the test and production, the cType hash would be the same.
+ */
 
 /**
  * Email Credential Type attested from SocialKYC.io
@@ -26,6 +31,8 @@ if (WSS_ADDRESS.includes('peregrine')) {
         requiredProperties: ['Email']
       },
       {
+        // SocialKYC will use this cType on the future.
+        // includes "'additionalProperties': false,"
         cTypeHash:
           '0xae5bc64e500eb576b7b137288cec5d532094e103be46872f1ad54641e477d9fe',
         trustedAttesters: [

--- a/backend/src/credentials/listOfRequests.ts
+++ b/backend/src/credentials/listOfRequests.ts
@@ -6,7 +6,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
  * Usually, attesters have different DIDs depending on the blockchain, i.e. production or testnet.
  *
  * On the other hand, a cType Hash is calculated from the cType structure.
- * If exactly the same structure is used on the test and production, the cType Hash will be the same.
+ * If exactly the same structure is used on the test and production chain, the cType Hash will be the same.
  */
 
 /**

--- a/backend/src/credentials/listOfRequests.ts
+++ b/backend/src/credentials/listOfRequests.ts
@@ -1,19 +1,54 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
+import { WSS_ADDRESS } from '../config'
+
 // Establish which cTypes our dApp accepts and which attesters we trust:
 
+// DIDs and cType-Hashes are different depending on the blockchain:
+
 /**
- * Email Credential Type attested from SocialKYC.io on the Spiritnet (Production) KILT Blockchain.
+ * Email Credential Type attested from SocialKYC.io
  */
-export const emailRequest: Kilt.IRequestCredentialContent = {
-  cTypes: [
-    {
-      cTypeHash:
-        '0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
-      trustedAttesters: [
-        'did:kilt:4pnfkRn5UurBJTW92d9TaVLR2CqJdY4z5HPjrEbpGyBykare'
-      ],
-      requiredProperties: ['Email']
-    }
-  ]
+export let emailRequest: Kilt.IRequestCredentialContent
+
+if (WSS_ADDRESS.includes('peregrine')) {
+  /**
+   * On the Peregrine (Test) KILT Blockchain.
+   */
+  emailRequest = {
+    cTypes: [
+      {
+        cTypeHash:
+          '0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
+        trustedAttesters: [
+          'did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY'
+        ],
+        requiredProperties: ['Email']
+      },
+      {
+        cTypeHash:
+          '0xae5bc64e500eb576b7b137288cec5d532094e103be46872f1ad54641e477d9fe',
+        trustedAttesters: [
+          'did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY'
+        ],
+        requiredProperties: ['Email']
+      }
+    ]
+  }
+} else {
+  /**
+   * On the Spiritnet (Production) KILT Blockchain.
+   */
+  emailRequest = {
+    cTypes: [
+      {
+        cTypeHash:
+          '0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
+        trustedAttesters: [
+          'did:kilt:4pnfkRn5UurBJTW92d9TaVLR2CqJdY4z5HPjrEbpGyBykare'
+        ],
+        requiredProperties: ['Email']
+      }
+    ]
+  }
 }

--- a/backend/src/credentials/listOfRequests.ts
+++ b/backend/src/credentials/listOfRequests.ts
@@ -3,7 +3,7 @@ import * as Kilt from '@kiltprotocol/sdk-js'
 // Establish which cTypes our dApp accepts and which attesters we trust:
 
 /**
- * Email Credential Type attested from SocialKYC.io
+ * Email Credential Type attested from SocialKYC.io on the Spiritnet (Production) KILT Blockchain.
  */
 export const emailRequest: Kilt.IRequestCredentialContent = {
   cTypes: [
@@ -11,15 +11,7 @@ export const emailRequest: Kilt.IRequestCredentialContent = {
       cTypeHash:
         '0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
       trustedAttesters: [
-        'did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY'
-      ],
-      requiredProperties: ['Email']
-    },
-    {
-      cTypeHash:
-        '0xae5bc64e500eb576b7b137288cec5d532094e103be46872f1ad54641e477d9fe',
-      trustedAttesters: [
-        'did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY'
+        'did:kilt:4pnfkRn5UurBJTW92d9TaVLR2CqJdY4z5HPjrEbpGyBykare'
       ],
       requiredProperties: ['Email']
     }

--- a/backend/src/credentials/listOfRequests.ts
+++ b/backend/src/credentials/listOfRequests.ts
@@ -1,61 +1,42 @@
 import * as Kilt from '@kiltprotocol/sdk-js'
 
-import { WSS_ADDRESS } from '../config'
-
 // Establish which cTypes our dApp accepts and which attesters we trust:
 
 /**
  * Usually, attesters have different DIDs depending on the blockchain, i.e. production or testnet.
  *
- * The cType Hash is calculated from the cType structure.
- * If exactly the same structure is used on the test and production, the cType hash would be the same.
+ * On the other hand, a cType Hash is calculated from the cType structure.
+ * If exactly the same structure is used on the test and production , the cType hash would be the same.
  */
 
 /**
  * Email Credential Type attested from SocialKYC.io
  */
-export let emailRequest: Kilt.IRequestCredentialContent
-
-if (WSS_ADDRESS.includes('peregrine')) {
-  /**
-   * On the Peregrine (Test) KILT Blockchain.
-   */
-  emailRequest = {
-    cTypes: [
-      {
-        cTypeHash:
-          '0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
-        trustedAttesters: [
-          'did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY'
-        ],
-        requiredProperties: ['Email']
-      },
-      {
-        // SocialKYC will use this cType on the future.
-        // includes "'additionalProperties': false,"
-        cTypeHash:
-          '0xae5bc64e500eb576b7b137288cec5d532094e103be46872f1ad54641e477d9fe',
-        trustedAttesters: [
-          'did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY'
-        ],
-        requiredProperties: ['Email']
-      }
-    ]
-  }
-} else {
-  /**
-   * On the Spiritnet (Production) KILT Blockchain.
-   */
-  emailRequest = {
-    cTypes: [
-      {
-        cTypeHash:
-          '0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
-        trustedAttesters: [
-          'did:kilt:4pnfkRn5UurBJTW92d9TaVLR2CqJdY4z5HPjrEbpGyBykare'
-        ],
-        requiredProperties: ['Email']
-      }
-    ]
-  }
+export const emailRequest: Kilt.IRequestCredentialContent = {
+  cTypes: [
+    {
+      cTypeHash:
+        '0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac',
+      trustedAttesters: [
+        /** SocialKYC on the KILT Peregrine (Test) Blockchain: */
+        'did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY',
+        /** SocialKYC on the KILT Spiritnet (Production) Blockchain: */
+        'did:kilt:4pnfkRn5UurBJTW92d9TaVLR2CqJdY4z5HPjrEbpGyBykare'
+      ],
+      requiredProperties: ['Email']
+    },
+    {
+      // On the future, SocialKYC will use this cType instead.
+      // which includes "'additionalProperties': false,"
+      cTypeHash:
+        '0xae5bc64e500eb576b7b137288cec5d532094e103be46872f1ad54641e477d9fe',
+      trustedAttesters: [
+        /** SocialKYC on the KILT Peregrine (Test) Blockchain: */
+        'did:kilt:4pehddkhEanexVTTzWAtrrfo2R7xPnePpuiJLC7shQU894aY',
+        /** SocialKYC on the KILT Spiritnet (Production) Blockchain: */
+        'did:kilt:4pnfkRn5UurBJTW92d9TaVLR2CqJdY4z5HPjrEbpGyBykare'
+      ],
+      requiredProperties: ['Email']
+    }
+  ]
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3093

Modifies `listOfRequests.ts` in a way that makes the project compatible with the both blockchains, Spiritnet and Peregrine. Now it could be merged into `main` an have all deployments depending on the same branch.