### PR TITLE
fix: update node to version 20 on workflows and containers

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Node and package manager
-        uses: actions/setup-node@v3.8.2
+        uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
           cache: 'yarn'

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.3-alpine as builder
+FROM node:20-alpine as builder
 
 WORKDIR /app
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.3-alpine as builder
+FROM node:20-alpine as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## fixes part of KILTProtocol/ticket#3081

- Makes sure the **GitHub workflows** uses node version 20. 
  For this following must be set: 
  - `actions/checkout@v4`
  - `actions/setup-node@v4` **with:**  _either_
    - **node-version-file:** '`package.json`' or '`.nvmrc`' 
    -  **node-version:**  `'`<Node.js version using [SemVer](https://semver.org/) or [aliases](https://github.com/nodejs/Release?tab=readme-ov-file#release-schedule) > `'`
 - Makes sure the **Dockerfiles** also use the node version 20. 
  This means that the following must be set: 
      - `FROM node:20-alpine as builder`